### PR TITLE
feat(HUB-186): adds protocol dropdown

### DIFF
--- a/src/elements/common/rvt-protocol-dropdown.ts
+++ b/src/elements/common/rvt-protocol-dropdown.ts
@@ -1,0 +1,35 @@
+import { LitElement, html } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { Rivet } from '@rivet-gg/api-internal';
+
+const PortProtocol = Rivet.cloud.version.matchmaker.common.PortProtocol;
+type PortProtocol = Rivet.cloud.version.matchmaker.common.PortProtocol;
+
+@customElement('rvt-protocol-dropdown')
+export default class RvtProtocolDropdown extends LitElement {
+	@property({ type: String })
+	selection: PortProtocol;
+
+	static PORT_PROTOCOLS_LABELS = {
+		[PortProtocol.Http]: 'HTTP',
+		[PortProtocol.Https]: 'HTTPS',
+		[PortProtocol.Tcp]: 'TCP',
+		[PortProtocol.TcpTls]: 'TCP TLS',
+		[PortProtocol.Udp]: 'UDP'
+	} satisfies Record<PortProtocol, string>;
+
+	static OPTIONS = Object.values(PortProtocol).map(value => ({
+		label: RvtProtocolDropdown.PORT_PROTOCOLS_LABELS[value],
+		value
+	}));
+
+	render() {
+		return html`
+			<drop-down-list
+				light
+				.selection=${RvtProtocolDropdown.OPTIONS.find(protocol => protocol.value == this.selection)}
+				.options=${RvtProtocolDropdown.OPTIONS}
+			></drop-down-list>
+		`;
+	}
+}

--- a/src/elements/pages/dev/game/pages/game-tokens.ts
+++ b/src/elements/pages/dev/game/pages/game-tokens.ts
@@ -1,28 +1,19 @@
 import { LitElement, html } from 'lit';
 import { customElement, property, queryAll } from 'lit/decorators.js';
+import { repeat } from 'lit/directives/repeat.js';
 import styles from './game-tokens.scss';
 import * as cloud from '@rivet-gg/cloud';
+import { Rivet } from '@rivet-gg/api-internal';
 import { responses } from '../../../../../routes';
 import { cssify } from '../../../../../utils/css';
 import global from '../../../../../utils/global';
 import { showAlert } from '../../../../../ui/helpers';
 import logging from '../../../../../utils/logging';
 import utils from '../../../../../utils/utils';
-import { DropDownSelectEvent, DropDownSelection } from '../../../../dev/drop-down-list';
+import { DropDownSelectEvent } from '../../../../dev/drop-down-list';
 import { TraversableErrors, VALIDATION_ERRORS } from '../../../../../utils/traversable-errors';
 import timing, { Debounce } from '../../../../../utils/timing';
 import { map } from 'lit/directives/map.js';
-
-const PORT_PROTOCOLS: DropDownSelection<cloud.ProxyProtocol>[] = [
-	{
-		label: 'HTTP',
-		value: cloud.ProxyProtocol.HTTP
-	},
-	{
-		label: 'HTTPS',
-		value: cloud.ProxyProtocol.HTTPS
-	}
-];
 
 interface Token {
 	name: string;
@@ -361,14 +352,10 @@ export default class DevGameTokens extends LitElement {
 														></text-input>
 													</td>
 													<td>
-														<drop-down-list
-															light
-															.selection=${PORT_PROTOCOLS.find(
-																pr => pr.value == (p.proxyProtocol as string)
-															)}
-															.options=${PORT_PROTOCOLS}
+														<rvt-protocol-dropdown
+															.selection=${p.proxyProtocol}
 															@select=${this.updatePortProtocol.bind(this, i)}
-														></drop-down-list>
+														></rvt-protocol-dropdown>
 													</td>
 													<td>
 														<icon-button


### PR DESCRIPTION
This pull request:
- [x] adds a new component - rvt-protocol-dropdown
- [x] rvt-protocol-dropdown behaves as a normal dropdown, but it's prefilled already with protocols from Fern API