### PR TITLE
feat(HUB-189): adds identity observer and confirmation popup

### DIFF
--- a/src/controllers/identityObserver.ts
+++ b/src/controllers/identityObserver.ts
@@ -1,0 +1,25 @@
+import { ReactiveController, ReactiveControllerHost } from 'lit';
+import { globalEventGroups, IdentityChangeEvent } from '../utils/global-events';
+import { IdentityProfile } from '@rivet-gg/identity';
+import global from '../utils/global';
+
+export class IdentityObserver implements ReactiveController {
+	public identity: IdentityProfile | null = global.currentIdentity || null;
+
+	constructor(private host: ReactiveControllerHost) {
+		host.addController(this);
+	}
+
+	hostConnected() {
+		globalEventGroups.add('identity-change', this.handleIdentityChange);
+	}
+
+	hostDisconnected() {
+		globalEventGroups.remove('identity-change', this.handleIdentityChange);
+	}
+
+	private handleIdentityChange = (e: IdentityChangeEvent) => {
+		this.identity = e.value;
+		this.host.requestUpdate();
+	};
+}

--- a/src/elements/common/toggle-switch.ts
+++ b/src/elements/common/toggle-switch.ts
@@ -6,7 +6,7 @@ import styles from './toggle-switch.scss';
 
 export class ToggleSwitchEvent extends Event {
 	constructor(public value: boolean) {
-		super('toggle');
+		super('toggle', { cancelable: true });
 	}
 }
 
@@ -27,10 +27,11 @@ export default class ToggleSwitch extends LitElement {
 		if (this.stopImmediatePropagation) e.stopImmediatePropagation();
 		if (this.isDisabled) return;
 
-		this.value = !this.value;
-
 		let event = new ToggleSwitchEvent(this.value);
-		this.dispatchEvent(event);
+		let isDispatched = this.dispatchEvent(event);
+		if (isDispatched) {
+			this.value = !this.value;
+		}
 	}
 
 	render() {

--- a/src/elements/pages/dev/user/settings.ts
+++ b/src/elements/pages/dev/user/settings.ts
@@ -214,16 +214,20 @@ export default class SettingsPage extends LitElement {
 	}
 
 	confirmAccountDeletion() {
-		showAlert('Are you sure?', html`After 30 days this action will be irreversible.`, [
-			{
-				label: 'Yes, delete my account',
-				destructive: true,
-				cb: () => this.settingChanged('toggle-deletion', true)
-			},
-			{
-				label: 'No, keep my account'
-			}
-		]);
+		showAlert(
+			'Schedule account deletion?',
+			html`After 30 days, your account will be permanently deleted.`,
+			[
+				{
+					label: 'Cancel'
+				},
+				{
+					label: 'Schedule Deletion',
+					destructive: true,
+					cb: () => this.settingChanged('toggle-deletion', true)
+				}
+			]
+		);
 	}
 
 	editModalClose() {


### PR DESCRIPTION
This pull request:
- [x] adds a confirmation popup when user tries to mark the account for deletion
- [x] moves identity subscription logic to a separate controller to reduce complexity of components (for now used only in profile settings)

https://github.com/rivet-gg/hub/assets/39823706/07b2e17b-64dc-439b-b6ad-45714533c6d4


