### PR TITLE
Fix claims expired error

### DIFF
--- a/src/elements/pages/analytics/overview.ts
+++ b/src/elements/pages/analytics/overview.ts
@@ -81,7 +81,7 @@ export default class AnalyticsOverview extends LitElement {
 	charts: Map<string, Chart> = new Map();
 
 	@property({ type: Boolean })
-	isLoading = true;
+	isLoading = false;
 
 	dateOptions: DropDownSelection<DateRange>[] = [
 		{ label: 'Past 10 Minutes', value: DateRange.Min10 },

--- a/src/utils/global.ts
+++ b/src/utils/global.ts
@@ -166,20 +166,21 @@ export class GlobalState {
 
 		// Create live instance.
 		logging.net('Connecting to live...', config.ORIGIN_API);
+
+		let getToken = async () => (await global.authManager.fetchToken()).token;
 		let fernFetcher = api.refreshFetcher(global);
 		this.api = new RivetClient({
 			environment: config.ORIGIN_API,
-			token: async () => (await global.authManager.fetchToken()).token,
+			token: getToken,
 			fetcher: fernFetcher
 		});
 		this.apiEe = new RivetEeClient({
 			environment: config.ORIGIN_API,
-			token: async () => (await global.authManager.fetchToken()).token,
+			token: getToken,
 			fetcher: fernFetcher
 		});
 
 		// Create Smithy API middleware, automatically refreshes the api token on expiration
-		let getToken = async () => (await global.authManager.fetchToken()).token;
 		let refreshMiddleware = (init?: RequestInit) => {
 			let requestHandlerMiddleware = api.requestHandlerMiddleware(getToken, init).handle;
 


### PR DESCRIPTION
Fixes HUB-313

The Fern client does not re-fetch the token from the fetcher, the token is passed to the fetcher. This means you need to manually set the auth header when refreshing the token