### PR TITLE
"Get Started" banner

### DIFF
--- a/src/elements/pages/dev/game/pages/game-overview.ts
+++ b/src/elements/pages/dev/game/pages/game-overview.ts
@@ -300,6 +300,19 @@ export default class DevGameOverview extends LitElement {
 		return html`
 			<div class="mx-auto max-w-contentwidth px-3 md:px-5 lg:px-0 pb-8">
 				<game-banner .game=${this.game}></game-banner>
+
+				${when(
+					this.game?.versions?.length == 1,
+					() =>
+						html`<a
+							class="flex mb-5 p-4 flex items-center justify-center bg-cream-100 text-charcole-900"
+							href="https://rivet.gg/learn"
+						>
+							Get started with examples or templates
+							<e-svg class="ms-2" src="regular/arrow-right"></e-svg>
+						</a>`
+				)}
+
 				<div class="flex flex-row w-full space-x-8 max-md:px-4 ">
 					${when(this.game, () => this.renderAnalytics(this.game))}
 					${when(this.game, () => this.renderNamespaceList(this.game))}


### PR DESCRIPTION
Fixes HUB-358

![image](https://github.com/rivet-gg/hub/assets/39823706/1db6d92c-7668-4342-b6fa-ab7c3427287d)

This message will disappear when user deploys their first version.
The work of making Rivet.gg Learn more visible in hub will be continued in HUB-364.