### PR TITLE
chore: add hardcoded cache bust

### DIFF
--- a/apps/hub/src/app.tsx
+++ b/apps/hub/src/app.tsx
@@ -50,7 +50,10 @@ export function App() {
   return (
     <PersistQueryClientProvider
       client={queryClient}
-      persistOptions={{ persister: queryClientPersister }}
+      persistOptions={{
+        persister: queryClientPersister,
+        buster: "Mon, 26 Aug 2024 03:02:12 GMT",
+      }}
     >
       <ConfigProvider value={getConfig()}>
         <ThirdPartyProviders>


### PR DESCRIPTION
See https://linear.app/rivet-gg/issue/HUB-489/pass-cache-busting-string-from-bootstrap-to-tanstack