### PR TITLE
fix: invalidate game backend cache when navigating to an environment without one

### DIFF
--- a/apps/hub/src/domains/game/helpers/try-create-backend.ts
+++ b/apps/hub/src/domains/game/helpers/try-create-backend.ts
@@ -16,12 +16,14 @@ export async function tryCreateBackend({
     if (isRivetError(error)) {
       if (error.body.code === "BACKEND_NOT_FOUND") {
         await rivetEeClient.ee.backend.create(gameId, environmentId, {});
-        await queryClient.invalidateQueries(
-          gameBackendQueryOptions({ gameId, environmentId }),
-        );
+        await queryClient.invalidateQueries({
+          ...gameBackendQueryOptions({ gameId, environmentId }),
+          refetchType: "all",
+        });
+        return;
       }
     }
     throw error;
   }
-  return {};
+  return;
 }


### PR DESCRIPTION
Closes RVTEE-549